### PR TITLE
Add BIND_INTERFACE env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ There are a series of available environment variables:
 | `BEASTHOST`          | Required. IP/Hostname of a Mode-S/BEAST provider (dump1090) | `readsb` |
 | `BEASTPORT`          | Optional. TCP port number of Mode-S/BEAST provider (dump1090) | `30005` |
 | `FR24KEY`            | Required. Flightradar24 Sharing Key | |
+| `BIND_INTERFACE`     | Optional. Set a bind interface such as `0.0.0.0` to allow access from non-private IP addresses | _none_ |
 | `TZ`                 | Your local timezone (optional)  | `GMT` |
 | `VERBOSE_LOGGING`    | Set to `true` to enable verbose logging (optional) | `false` |
 

--- a/rootfs/etc/cont-init.d/01-fr24feed
+++ b/rootfs/etc/cont-init.d/01-fr24feed
@@ -34,6 +34,9 @@ fi
   echo logpath="/var/log"
   echo mlat="no"
   echo mlat-without-gps="no"
+  if [ -n "${BIND_INTERFACE}" ]; then
+    echo bind-interface="${BIND_INTERFACE}"
+  fi
 } > /etc/fr24feed.ini
 
 # prepare directories (from /usr/lib/fr24/create_missing_directories.sh)


### PR DESCRIPTION
Allows setting the `bind-interface` config option in fr24feed.ini
to allow access from non-private IP addresses. Can be set to
`0.0.0.0` to allow access from any IP address (warning, may be
insecure). If env var is not set (default), the config option
will not be added to the config file, which is a secure default.

Fixes #58