### PR TITLE
limit fr24feed to 128 open file descriptors

### DIFF
--- a/rootfs/etc/s6-overlay/scripts/fr24feed
+++ b/rootfs/etc/s6-overlay/scripts/fr24feed
@@ -3,6 +3,10 @@
 
 source /scripts/common
 
+# fr24feed regularly uses fcntl on all available fds, causing CPU / syscall load
+# limit fr24feed to 128 open file descriptors to work around this issue
+ulimit -n 128
+
 # don't start if the signup-uat.sh script is running
 #while [[ -f /run/.pause-fr24feed ]]; do
 #  sleep 1

--- a/rootfs/etc/s6-overlay/scripts/fr24uat-feed
+++ b/rootfs/etc/s6-overlay/scripts/fr24uat-feed
@@ -9,6 +9,10 @@ if [[ -z "$FR24KEY_UAT" ]]; then
   sleep infinity
 fi
 
+# fr24feed regularly uses fcntl on all available fds, causing CPU / syscall load
+# limit fr24feed to 128 open file descriptors to work around this issue
+ulimit -n 128
+
 # don't start if the signup-uat.sh script is running
 #while [[ -f /run/.pause-fr24feed ]]; do
 #  sleep 1


### PR DESCRIPTION
fr24feed regularly uses fcntl on all available fds, causing CPU / syscall load
limit fr24feed to 128 open file descriptors to work around this issue

See also https://discord.com/channels/734090820684349521/734090821250580564/1228341697327534132

I can confirm the CPU increase every 15 seconds or so when all the available FDs are scanned.

strace also confirms this is what is happening, now it only iterates over 128 fds which is acceptable:
```
[2024-04-13 19:07:51.470] [pid 1761206] fcntl(119, F_GETFD)       = -1 EBADF (Bad file descriptor)
[2024-04-13 19:07:51.470] [pid 1761206] fcntl(120, F_GETFD)       = -1 EBADF (Bad file descriptor)
[2024-04-13 19:07:51.470] [pid 1761206] fcntl(121, F_GETFD)       = -1 EBADF (Bad file descriptor)
[2024-04-13 19:07:51.470] [pid 1761206] fcntl(122, F_GETFD)       = -1 EBADF (Bad file descriptor)
[2024-04-13 19:07:51.470] [pid 1761206] fcntl(123, F_GETFD)       = -1 EBADF (Bad file descriptor)
[2024-04-13 19:07:51.470] [pid 1761206] fcntl(124, F_GETFD)       = -1 EBADF (Bad file descriptor)
[2024-04-13 19:07:51.470] [pid 1761206] fcntl(125, F_GETFD)       = -1 EBADF (Bad file descriptor)
[2024-04-13 19:07:51.471] [pid 1761206] fcntl(126, F_GETFD)       = -1 EBADF (Bad file descriptor)
[2024-04-13 19:07:51.471] [pid 1761206] fcntl(127, F_GETFD)       = -1 EBADF (Bad file descriptor)
```