### PR TITLE
Build Optimizations to drastically shrink image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,7 @@ RUN --mount=type=bind,from=build,source=/,target=/build/ \
     else qemu-arm-static /usr/local/bin/fr24feed --version > /.CONTAINER_VERSION; \
     fi \
     && \
-    cat /CONTAINER_VERSION
+    cat /.CONTAINER_VERSION
 
 COPY rootfs/ /
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ RUN --mount=type=bind,from=build,source=/,target=/build/ \
     cp -f /build/usr/bin/fr24feed-status /usr/bin/fr24feed-status && \
     ln -s /usr/bin/fr24feed /usr/local/bin/fr24feed && \
     ln -s /usr/bin/fr24feed-status /usr/local/bin/fr24feed-status && \
-    tar zxf /build/mlatclient.tgz -C / && \
+ #   tar zxf /build/mlatclient.tgz -C / && \
     apt-get remove -y "${TEMP_PACKAGES[@]}" && \
     apt-get autoremove -y && \
     rm -rf /src/* /tmp/* /var/lib/apt/lists/* && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,8 @@ ENV S6_BEHAVIOUR_IF_STAGE2_FAILS=2 \
     MLAT=no \
     VERBOSE_LOGGING=false \
 
-ARG VERSION_REPO="sdr-enthusiasts/docker-flightradar24" VERSION_BRANCH="##BRANCH##"
+ARG VERSION_REPO="sdr-enthusiasts/docker-flightradar24" \
+    VERSION_BRANCH="##BRANCH##"
 
 # NEW STUFF BELOW
 # hadolint ignore=DL3008,SC2086,SC2039,SC2068

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,9 +24,9 @@ RUN --mount=type=bind,from=build,source=/,target=/build/ \
     # required monitor incoming traffic from beasthost
     KEPT_PACKAGES+=(tcpdump) && \
     KEPT_PACKAGES+=(jq) && \
-    if [[ "${TARGETARCH:0:3}" != "arm" ]]; then \
-        KEPT_PACKAGES+=(qemu-user-static); \
-    fi && \
+    # if [[ "${TARGETARCH:0:3}" != "arm" ]]; then \
+    #     KEPT_PACKAGES+=(qemu-user-static); \
+    # fi && \
     apt-get update && \
     apt-get install -y --no-install-recommends \
     "${KEPT_PACKAGES[@]}" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/sdr-enthusiasts/docker-baseimage:mlatclient AS build
+FROM ghcr.io/sdr-enthusiasts/docker-baseimage:base AS build
 SHELL ["/bin/bash", "-x", "-o", "pipefail", "-c"]
 COPY install_feeder.sh /
 # hadolint ignore=SC2016
@@ -24,8 +24,6 @@ RUN --mount=type=bind,from=build,source=/,target=/build/ \
     # required monitor incoming traffic from beasthost
     KEPT_PACKAGES+=(tcpdump) && \
     KEPT_PACKAGES+=(jq) && \
-    # required for mlatclient:
-    KEPT_PACKAGES+=(python3-pkg-resources) && \
     if [[ "${TARGETARCH:0:3}" != "arm" ]]; then \
         KEPT_PACKAGES+=(qemu-user-static); \
     fi && \
@@ -38,9 +36,9 @@ RUN --mount=type=bind,from=build,source=/,target=/build/ \
     cp -f /build/usr/bin/fr24feed-status /usr/bin/fr24feed-status && \
     ln -s /usr/bin/fr24feed /usr/local/bin/fr24feed && \
     ln -s /usr/bin/fr24feed-status /usr/local/bin/fr24feed-status && \
- #   tar zxf /build/mlatclient.tgz -C / && \
     apt-get remove -y "${TEMP_PACKAGES[@]}" && \
-    apt-get autoremove -y && \
+    apt-get autoremove -q -o APT::Autoremove::RecommendsImportant=0 -o APT::Autoremove::SuggestsImportant=0 -y && \
+    apt-get clean -q -y && \
     rm -rf /src/* /tmp/* /var/lib/apt/lists/* && \
     # Document version
     if /usr/local/bin/fr24feed --version > /dev/null 2>&1; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ ENV S6_BEHAVIOUR_IF_STAGE2_FAILS=2 \
     BEASTHOST=readsb \
     BEASTPORT=30005 \
     MLAT=no \
-    VERBOSE_LOGGING=false \
+    VERBOSE_LOGGING=false
 
 ARG VERSION_REPO="sdr-enthusiasts/docker-flightradar24" \
     VERSION_BRANCH="##BRANCH##"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/sdr-enthusiasts/docker-baseimage:mlatclient as build
+FROM ghcr.io/sdr-enthusiasts/docker-baseimage:mlatclient AS build
 SHELL ["/bin/bash", "-x", "-o", "pipefail", "-c"]
 COPY install_feeder.sh /
 # hadolint ignore=SC2016
@@ -13,7 +13,7 @@ ENV S6_BEHAVIOUR_IF_STAGE2_FAILS=2 \
     BEASTPORT=30005 \
     MLAT=no \
     VERBOSE_LOGGING=false
-ARG TARGETPLATFORM
+ARG TARGETPLATFORM TARGETARCH
 
 # NEW STUFF BELOW
 # hadolint ignore=DL3008,SC2086,SC2039,SC2068

--- a/rootfs/etc/s6-overlay/scripts/01-fr24feed
+++ b/rootfs/etc/s6-overlay/scripts/01-fr24feed
@@ -45,7 +45,7 @@ fi
   echo raw="no"
   echo logmode="1"
   echo logpath="/var/log"
-  if [ -z "${MLAT}" ]; then
+  if ! chk_enabled "${MLAT}"; then
     echo mlat="no"
     echo mlat-without-gps="no"
   else
@@ -84,7 +84,7 @@ if /usr/local/bin/fr24feed --version > /dev/null 2>&1; then
   echo "fr24feed version: $(/usr/local/bin/fr24feed --version)"
 else
   # fr24feed needs qemu
-  echo "fr24feed version: $(qemu-arm-static /usr/local/bin/fr24feed --version)"
+  echo "fr24feed version: $(qemu-arm-static /usr/local/bin/fr24feed --version) (using qemu)"
 fi
 
 # prepare log file

--- a/rootfs/etc/s6-overlay/scripts/01-fr24feed
+++ b/rootfs/etc/s6-overlay/scripts/01-fr24feed
@@ -1,19 +1,21 @@
 #!/command/with-contenv bash
 # shellcheck shell=bash
-# shellcheck disable=SC2153
+# shellcheck disable=SC2153,SC1091,SC2154
+
+source /scripts/common
 
 # Check to make sure the correct command line arguments have been set
 EXITCODE=0
 if [ -z "${BEASTHOST}" ]; then
-  echo "ERROR: BEASTHOST environment variable not set"
+  "${s6wrap[@]}" echo "ERROR: BEASTHOST environment variable not set"
   EXITCODE=1
 fi
 if [ -z "${FR24KEY}" ]; then
-  echo "ERROR: FR24KEY environment variable not set"
+  "${s6wrap[@]}" echo "ERROR: FR24KEY environment variable not set"
   EXITCODE=1
 fi
 if [ -n "${FR24_SIGNUP}" ]; then
-  echo "even with missing keys, simply start the signup script"
+  "${s6wrap[@]}" echo "even with missing keys, simply start the signup script"
   EXITCODE=0
   SIGNUP=1
 fi
@@ -27,7 +29,7 @@ fi
 # 22-12-15 16:19:09.421 [E][:] Your machine should be set as GMT+0 time zone!
 # 22-12-15 16:19:09.421 [W][:] Time zone is not set to GMT+0
 if [ -n "${TZ}" ]; then
-  echo "WARNING: Setting timezone via TZ is ignored for this container because fr24feed requires the container to use timezone GMT (+0)."
+  "${s6wrap[@]}" echo "WARNING: Setting timezone via TZ is ignored for this container because fr24feed requires the container to use timezone GMT (+0)."
 fi
 printf "GMT" > /var/run/s6/container_environment/TZ
 
@@ -81,10 +83,10 @@ touch /dev/shm/decoder.txt
 # Test fr24feed can run natively (without qemu)
 if /usr/local/bin/fr24feed --version > /dev/null 2>&1; then
   # fr24feed can be run natively
-  echo "fr24feed version: $(/usr/local/bin/fr24feed --version)"
+  "${s6wrap[@]}" echo "fr24feed version: $(/usr/local/bin/fr24feed --version)"
 else
   # fr24feed needs qemu
-  echo "fr24feed version: $(qemu-arm-static /usr/local/bin/fr24feed --version) (using qemu)"
+  "${s6wrap[@]}" echo "fr24feed version: $(qemu-arm-static /usr/local/bin/fr24feed --version) (using qemu)"
 fi
 
 # prepare log file

--- a/rootfs/etc/s6-overlay/scripts/01-fr24feed
+++ b/rootfs/etc/s6-overlay/scripts/01-fr24feed
@@ -90,5 +90,5 @@ else
 fi
 
 # prepare log file
-rm /var/log/fr24feed.log > /dev/null 2>&1
+rm -f /var/log/fr24feed.log
 touch /var/log/fr24feed.log

--- a/rootfs/etc/s6-overlay/scripts/02-show-architecture
+++ b/rootfs/etc/s6-overlay/scripts/02-show-architecture
@@ -1,12 +1,12 @@
 #!/command/with-contenv bash
-# shellcheck shell=bash
+# shellcheck shell=bash disable=SC1091,SC2154
 
-white="\e[0;97m"
-reset="\e[0m"
+source /scripts/common
 
-echo -e "${white}"
-echo "Hardware information:"
-echo "Machine:   $(uname -m)"
-echo "Processor: $(uname -p)"
-echo "Platform:  $(uname -i)"
-echo -e "${reset}"
+"${s6wrap[@]}" echo "Container version: $(</.CONTAINER_VERSION)"
+"${s6wrap[@]}" echo ""
+"${s6wrap[@]}" echo "Hardware information:"
+"${s6wrap[@]}" echo "Machine:   $(uname -m)"
+"${s6wrap[@]}" echo "Processor: $(uname -p)"
+"${s6wrap[@]}" echo "Platform:  $(uname -i)"
+


### PR DESCRIPTION
Size comparison of old vs (test build of) new:

on `arm64`:
```
REPOSITORY                                        TAG        IMAGE ID       CREATED             SIZE
adsb-fr24                                         latest     7a6a03e578bb   37 seconds ago      193MB
ghcr.io/sdr-enthusiasts/docker-flightradar24      latest     d69d7d67626a   About an hour ago   495MB 
```

on `amd64`:
```
REPOSITORY                                        TAG        IMAGE ID       CREATED             SIZE
ghcr.io/sdr-enthusiasts/docker-flightradar24      latest     24ae41648f6c   2 minutes ago       163MB
ghcr.io/sdr-enthusiasts/docker-flightradar24      <none>     e663d98962a8   About an hour ago   471MB
```