### PR TITLE
re-add filter term

### DIFF
--- a/rootfs/etc/s6-overlay/scripts/fr24feed
+++ b/rootfs/etc/s6-overlay/scripts/fr24feed
@@ -35,6 +35,7 @@ else
   FILTER_TERMS+=("-e" "[feed][i]sent")
   FILTER_TERMS+=("-e" "[feed][n]syncing")
   FILTER_TERMS+=("-e" "[feed][n]ping 1")
+  FILTER_TERMS+=("-e" "[feed][i]filtering")
   VERBOSE_REMARK="in non-verbose logging mode"
 fi
 


### PR DESCRIPTION
seems this log output is still present for some instances, thus needs filtering when not verbose