### PR TITLE
use process substition + exec instead of pipe

### DIFF
--- a/rootfs/etc/s6-overlay/scripts/fr24feed
+++ b/rootfs/etc/s6-overlay/scripts/fr24feed
@@ -42,7 +42,7 @@ fi
 "${s6wrap[@]}" echo "Starting fr24feed (adsb) $NATIVE $VERBOSE_REMARK"
 
 if [[ ${#FILTER_TERMS[@]} == 0 ]]; then
-    "${s6wrap[@]}" "${FR24_CMD[@]}"
+    exec "${s6wrap[@]}" "${FR24_CMD[@]}"
 else
-    "${s6wrap[@]}" "${FR24_CMD[@]}" | stdbuf -oL grep -v -F "${FILTER_TERMS[@]}"
+    exec "${s6wrap[@]}" "${FR24_CMD[@]}" > >(grep --line-buffered -v -F "${FILTER_TERMS[@]}")
 fi

--- a/rootfs/etc/s6-overlay/scripts/fr24uat-feed
+++ b/rootfs/etc/s6-overlay/scripts/fr24uat-feed
@@ -47,4 +47,4 @@ else
 fi
 
 "${s6wrap[@]}" echo "Starting fr24feed (adsb) $NATIVE_REMARK $VERBOSE_REMARK"
-"${s6wrap[@]}" "${FR24_CMD[@]}" | stdbuf -oL grep -v -F "${FILTER_TERMS[@]}"
+exec "${s6wrap[@]}" "${FR24_CMD[@]}" > >(grep --line-buffered -v -F "${FILTER_TERMS[@]}")


### PR DESCRIPTION
exec in bash doesn't work on pipes
but it works with process subsitition so use that and exec

using exec is generally better due to s6-supervise being able to
properly terminate it