### PR TITLE
add dns_search to yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ services:
     environment:
       - BEASTHOST=beasthost
       - FR24KEY=xxxxxxxxxxx
+    dns_search: . # prevents rare connection issues related to a bug in docker and fr24feed
 ```
 
 ## Runtime Environment Variables


### PR DESCRIPTION
this prevents a rare connection issues mostly when people run pihole DNS

with a search domain set in /etc/resolv.conf, the search domain is added by docker which is a bug.

this results in query responses such as :: which in turn seem to make fr24feed use that response and thus not being able to connect. another bug.

in other words the perfect storm