### PR TITLE
Add support for setting a custom ntp-server through an environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ There are a series of available environment variables:
 | `FR24KEY_UAT`        | Optional. Only used if you are feeding UAT data - see section below                            | _empty_   |
 | `UATHOST`            | Optional. Only used if you are feeding UAT data and you don't use the default value            | `dump978` |
 | `UATPORT`            | Optional. Only used if you are feeding UAT data and you don't use the default value            | `30978`   |
+| `NTP_SERVER`         | Optional. A custom NTP server to override the defaults.                                        | _none_    |
 
 ## Ports
 

--- a/rootfs/etc/s6-overlay/scripts/01-fr24feed
+++ b/rootfs/etc/s6-overlay/scripts/01-fr24feed
@@ -58,6 +58,9 @@ fi
     if [ -n "${BIND_INTERFACE}" ]; then
         echo bind-interface="${BIND_INTERFACE}"
     fi
+    if [ -n "${NTP_SERVER}" ]; then
+        echo ntp-server="${NTP_SERVER}"
+    fi
 } >/etc/fr24feed.ini
 
 if [[ -n "$FR24KEY_UAT" ]]; then


### PR DESCRIPTION
Add support for setting ntp-server in the generated fr24feed.ini using the NTP_SERVER environment variable passed to the container